### PR TITLE
android: mark dependencies as `implementation` rather than `compile`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,10 +19,10 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.madgag.spongycastle:core:1.58.0.0'
-    compile 'com.madgag.spongycastle:prov:1.54.0.0'
-    compile 'com.madgag.spongycastle:pkix:1.54.0.0'
-    compile 'com.madgag.spongycastle:pg:1.54.0.0'
+    implementation 'com.android.support:appcompat-v7:23.0.1'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.madgag.spongycastle:core:1.58.0.0'
+    implementation 'com.madgag.spongycastle:prov:1.54.0.0'
+    implementation 'com.madgag.spongycastle:pkix:1.54.0.0'
+    implementation 'com.madgag.spongycastle:pg:1.54.0.0'
 }


### PR DESCRIPTION
This ports existing patch from `metamask-mobile`: https://github.com/MetaMask/metamask-mobile/blob/main/patches/react-native-aes-crypto-forked%2B1.2.1.patch

https://github.com/MetaMask/metamask-mobile/blob/060ff000c44a865d72461363341fb633f6a3f5d8/package.json#L258