### PR TITLE
Release v1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@metamask/react-native-aes-crypto",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "AES crypto native module for react-native",
     "main": "index.js",
     "author": "tectiv3",


### PR DESCRIPTION
This is the release candidate for `@metamask/react-native-aes-crypto` v1.2.2.

Changes since v1.2.1:
- #4 